### PR TITLE
Replaces `Activity` with `Context` in `JailbreakRootDetectionPlugin`

### DIFF
--- a/android/src/main/kotlin/com/w3conext/jailbreak_root_detection/JailbreakRootDetectionPlugin.kt
+++ b/android/src/main/kotlin/com/w3conext/jailbreak_root_detection/JailbreakRootDetectionPlugin.kt
@@ -1,6 +1,7 @@
 package com.w3conext.jailbreak_root_detection
 
 import android.app.Activity
+import android.content.Context
 import com.anish.trust_fall.emulator.EmulatorCheck
 import com.anish.trust_fall.externalstorage.ExternalStorageCheck
 import com.anish.trust_fall.rooted.RootedCheck
@@ -22,7 +23,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 /** JailbreakRootDetectionPlugin */
-class JailbreakRootDetectionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
+class JailbreakRootDetectionPlugin : FlutterPlugin, MethodCallHandler {
 
     /// The MethodChannel that will the communication between Flutter and native Android
     ///
@@ -30,9 +31,10 @@ class JailbreakRootDetectionPlugin : FlutterPlugin, MethodCallHandler, ActivityA
     /// when the Flutter Engine is detached from the Activity
     private lateinit var channel: MethodChannel
 
-    private var activity: Activity? = null
+    private lateinit var appContext: Context
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        appContext = flutterPluginBinding.applicationContext
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "jailbreak_root_detection")
         channel.setMethodCallHandler(this)
     }
@@ -43,11 +45,11 @@ class JailbreakRootDetectionPlugin : FlutterPlugin, MethodCallHandler, ActivityA
             "isJailBroken" -> processJailBroken(result)
             "isRealDevice" -> result.success(!EmulatorCheck.isEmulator)
             "isOnExternalStorage" -> result.success(
-                ExternalStorageCheck.isOnExternalStorage(activity)
+                ExternalStorageCheck.isOnExternalStorage(appContext)
             )
 
-            "isDevMode" -> result.success(DevMode.isDevMode(activity))
-            "isDebugged" -> result.success(Debugger.isDebugged(activity))
+            "isDevMode" -> result.success(DevMode.isDevMode(appContext))
+            "isDebugged" -> result.success(Debugger.isDebugged(appContext))
             else -> result.notImplemented()
         }
     }
@@ -56,28 +58,14 @@ class JailbreakRootDetectionPlugin : FlutterPlugin, MethodCallHandler, ActivityA
         channel.setMethodCallHandler(null)
     }
 
-    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        activity = binding.activity
-    }
-
-    override fun onDetachedFromActivityForConfigChanges() {}
-
-    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-        activity = binding.activity
-    }
-
-    override fun onDetachedFromActivity() {
-        activity = null
-    }
-
     private fun processCheckIssues(result: Result) {
         val scope = CoroutineScope(Job() + Dispatchers.Default)
         scope.launch {
 
-            QLog.LOGGING_LEVEL = QLog.NONE;
+            QLog.LOGGING_LEVEL = QLog.NONE
 
             val issues = mutableListOf<String>()
-            if (RootedCheck.isJailBroken(activity)) {
+            if (RootedCheck.isJailBroken(appContext)) {
                 issues.add("jailbreak")
             }
 
@@ -85,11 +73,11 @@ class JailbreakRootDetectionPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                 issues.add("fridaFound")
             }
 
-            if (Debugger.isDebugged(activity)) {
+            if (Debugger.isDebugged(appContext)) {
                 issues.add("debugged")
             }
 
-            if (DevMode.isDevMode(activity)) {
+            if (DevMode.isDevMode(appContext)) {
                 issues.add("devMode")
             }
 
@@ -101,7 +89,7 @@ class JailbreakRootDetectionPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                 issues.add("notRealDevice")
             }
 
-            if (ExternalStorageCheck.isOnExternalStorage(activity)) {
+            if (ExternalStorageCheck.isOnExternalStorage(appContext)) {
                 issues.add("onExternalStorage")
             }
 
@@ -115,7 +103,7 @@ class JailbreakRootDetectionPlugin : FlutterPlugin, MethodCallHandler, ActivityA
 
             QLog.LOGGING_LEVEL = QLog.NONE;
 
-            val isRootBeer = RootedCheck.isJailBroken(activity)
+            val isRootBeer = RootedCheck.isJailBroken(appContext)
             val isFrida = AntiFridaChecker.checkFrida()
             val isMagisk = MagiskChecker.isInstalled()
             val isRooted = isRootBeer || isFrida || isMagisk


### PR DESCRIPTION
Currently the plugin does not work in the background on Android which is solved by removing `Activity`.

Closes #27 